### PR TITLE
Add material for 2019 session on collections

### DIFF
--- a/2019/.gitignore
+++ b/2019/.gitignore
@@ -1,0 +1,4 @@
+target/
+project/
+logs/
+.DS_STORE

--- a/2019/build.sbt
+++ b/2019/build.sbt
@@ -1,0 +1,15 @@
+ThisBuild / scalaVersion     := "2.13.1"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / organization     := "com.gu.scalaschool"
+ThisBuild / organizationName := "The Guardian"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "scala-school-2019",
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % "3.0.8",
+      "joda-time" % "joda-time" % "2.10.5"
+    )
+  )
+
+// See https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html for instructions on how to publish to Sonatype.

--- a/2019/src/main/scala/collections/FoldDemo.scala
+++ b/2019/src/main/scala/collections/FoldDemo.scala
@@ -1,0 +1,6 @@
+package collections
+
+object FoldDemo {
+
+
+}

--- a/2019/src/main/scala/collections/MapDemo.scala
+++ b/2019/src/main/scala/collections/MapDemo.scala
@@ -1,0 +1,21 @@
+package collections
+
+object MapDemo {
+
+  //for when you need to square every element in a list
+  def squarer(numbers: List[Int]): List[Int] = ???
+
+  val studentResults = Map[String, List[Double]](
+    "123" -> List(57, 50, 70, 78),
+    "124" -> List(60, 60, 51),
+    "125" -> List(55, 57, 78)
+  )
+
+  //note:
+  //scala> List(1, 2, 3).sum
+  //res38: Int = 6
+
+  def averageGrade(studentId: String): Option[Double] = ???
+
+
+}

--- a/2019/src/main/scala/collections/OptionsDemo.scala
+++ b/2019/src/main/scala/collections/OptionsDemo.scala
@@ -1,0 +1,7 @@
+package collections
+
+object OptionsDemo {
+
+  //Users are not asked for their name on sign up. Did this user add their info later?
+  def userHasUpdatedProfile(identityId: String, firstName: Option[String], lastName: Option[String]): Boolean = ???
+}

--- a/2019/src/main/scala/collections/collectionsDemo.sc
+++ b/2019/src/main/scala/collections/collectionsDemo.sc
@@ -1,0 +1,140 @@
+// Commonly used collections
+
+// Lists
+// * preserve order
+// * can contain duplicates
+// * are immutable
+// * are implemented as linked list
+// Try some exercises here: https://www.scala-exercises.org/std_lib/lists
+
+// Lists are often thought about in terms of head and tail
+val numbers = List(1, 2, 3)
+println(s"head: ${numbers.head}") // should be 1
+println(s"tail: ${numbers.tail}")// should be List(2, 3)
+
+// you can add elements to a list by appending to the list as the head
+val zeroIndexedNumbers = 0 :: numbers
+
+// Let's create a list
+val favouriteRailStations: List[String] = List("Euston", "Kings Cross", "Moorgate", "Blackfriars")
+
+// An empty list is Nil
+val emptyList = Nil
+
+// Euston is dead to me
+// favouriteRailStations(0) = "Marylebone"
+
+// oops, doesn't compile because Lists are immutable
+// I still want the other stations
+val stationsMinusEuston = favouriteRailStations.tail
+
+// these are my favourites
+val topLondonRailStationsIn2019 = "Marylebone" :: stationsMinusEuston
+
+//we may often wish to apply a function to a list
+def londonise(station: String): String = s"London ${station}"
+
+// not all of my favourite stations are in London
+// map applies a function to every element in this list. More later.
+val londonStations = topLondonRailStationsIn2019.map(londonise)
+val topStations = "Glasgow Queen Street" :: "Fishguard Harbour" :: "Glasgow Central" :: londonStations
+
+// we can apply filters to lists
+val glasgowStations = topStations.filter(station => station.startsWith("Glasgow"))
+
+//when you use lists pick the head
+val firstStation = topStations.head // just picks the first item
+
+//but you'll need to ask for head as an option
+//because you might not get an element back if your list is Nil
+
+// Options
+// * are not a collection
+// * but are relevant to collections, when you request an item from a collection that might not be there
+
+// topStations.headOption will return Some("Glasgow Queen Street") because the list did have a head
+// Nil.headOption will return None because the list is empty
+
+// but actually use headOption, because you might not get an element back if your list is Nil
+val firstStationOption = topStations.headOption
+
+firstStationOption map { station =>
+  println(s"There was a station in the list, and it was $station")
+}
+
+//throws an error
+//println(s"There was a station in the list, and it was ${emptyList.head}")
+
+// just doesn't print
+emptyList.headOption map { station =>
+  println(s"There was a station in the list, and it was $station")
+}
+
+// you can access items in a list by index
+val secondStation = topStations(1)
+
+// but just because you can, doesn't mean you should
+val lastStation = topStations(topStations.length - 1) //gets the last element, but checks every element in the list
+
+// Vectors
+// * preserve order
+// * can contain duplicates
+// * are immutable
+// * are implemented in a way to be better at random access
+
+//vectors are implemented so that random access is nearly as fast as just plucking the first element
+val topStationsVector = topStations.toVector
+val lastStationSpeedier = topStationsVector(topStations.length - 1)
+
+//use vectors if you know you need random access, otherwise use lists.
+
+// Sets
+// * do not care about order
+// * cannot contain duplicates
+// * are immutable
+// So, sets in Scala work like mathematical sets
+// Try some exercises here: https://www.scala-exercises.org/std_lib/sets
+val validMethods = Set("GET", "GET", "POST")
+println(validMethods) // will print Set(GET, POST)
+//shows we don't care about order
+val methodToCheck = "DELETE"
+val isAllowed = validMethods.contains(methodToCheck)
+
+
+// Maps
+// * are immutable
+// * can hold a key/value pair
+// Try some exercises here: https://www.scala-exercises.org/std_lib/maps
+val provincesAndTerritories = Map(
+  "BC" -> "British Columbia",
+  "AB" -> "Alberta",
+  "MB" -> "Manitoba",
+  "SK" -> "Saskatchewan",
+  "ON" -> "Ontario",
+  "QC" -> "Quebec",
+  "NL" -> "Newfoundland",
+  "NS" -> "Nova Scotia",
+  "PE" -> "Prince Edward Island",
+  "YK" -> "Yukon Territory",
+  "NT" -> "Northwest Territories"
+)
+
+val longNameForQC = provincesAndTerritories("QC")
+
+def greetACanadian(provinceCode: String): String = {
+  s"Hi there friend! I see you have come from ${provincesAndTerritories(provinceCode)}"
+}
+
+println(greetACanadian("MB"))
+
+//but you might try to access an element in the map that doesn't exist
+// println(greetACanadian("AA")) will throw a java.util.NoSuchElementException
+
+def greetACanadianMoreSafely(provinceCode: String): String = {
+  provincesAndTerritories.get(provinceCode) match {
+    case Some(longerName) => s"Hi there friend! I see you have come from $longerName"
+    case None => "Hi there friend! I don't recognise the province you gave me, but welcome anyway!"
+  }
+}
+
+greetACanadianMoreSafely("BLAH")

--- a/2019/src/main/scala/collections/mapDemo.sc
+++ b/2019/src/main/scala/collections/mapDemo.sc
@@ -1,0 +1,45 @@
+// map applies a function to every item in the structure
+// it's good for lists
+def doubleIt(number: Int): Int = number * 2
+
+val numbers = List(1, 2, 3, 4)
+val doubleItNumbers = numbers.map(doubleIt) // it so happens that double it is a function f: Int => Int
+//but the function just needs to take an integer as input if we apply it to a list of strings
+
+def numberPositiveMessage(number: Int): String = s"$number is a great number"
+
+val flatterNumbers = numbers.map(numberPositiveMessage)
+
+//We can map over options and specify a function to apply if name is Some
+def messageOnlyIfName(name: Option[String]) = {
+  name map { name => s"Hello $name"}
+}
+
+messageOnlyIfName(Some("Carlos")) //Some(Hello Carlos)
+messageOnlyIfName(None) //None
+
+//If we need to avoid nested structures i.e. lists of lists, Option[Option[Int]] etc
+//we may want to flatmap
+// flatmap combines mapping, then flattening in nexted structures
+val nestedNumbers = List(List(1, 2), List(3, 4))
+val numbersDoubled = nestedNumbers.map { numberList: Seq[Int] => // map applies a function to each element and each element is a list
+  numberList map { //then, for each list let's double every number in the list
+    number => number * 2
+  }
+}
+
+//oops, that's not what we want
+
+numbersDoubled.flatten //List(2, 4, 5, 6)
+//that's better
+
+//even better:
+nestedNumbers.flatMap (list => list map (number => number * 2))
+
+//a real example of flatMap in the wild
+//https://github.com/guardian/identity/blob/82ebe24cc3266c45932bad176b81058b66f2f746/identity-api/src/main/scala/com/gu/identity/api/servlet/RedirectServlet.scala#L32
+
+// you can also use flatMap to discard Nones in a list
+val strings = Seq("1", "2", "foo", "3", "bar")
+val stringsAsOptions = strings.map(string => string.toIntOption)
+val stringsAsInts = strings.flatMap(string => string.toIntOption)

--- a/2019/src/main/scala/collections/optionsDemo.sc
+++ b/2019/src/main/scala/collections/optionsDemo.sc
@@ -1,0 +1,40 @@
+//Hello and welcome to this demo about Options
+
+// Let's write a simple function that will wish someone a happy birthday
+
+def greetSomeoneOnTheirBirthday(name: String) = s"Happy birthday, dear ${name}. Happy birthday to you!"
+
+greetSomeoneOnTheirBirthday("Karen")
+
+// Let's say we want to now customise this greeting if we know the person's age.
+// But we will not force this issue. Maybe this person doesn't wish to share.
+
+// We can make age an Option, because we should be able to handle when it's provided and when it isn't
+
+val age: Option[Int] = Some(45)
+val noAge: Option[Int] = None
+
+// greetSomeoneOnTheirBirthday("Karen", Some(45))  -  we will greet Karen, who is 45 today
+// greetSomeoneOnTheirBirthday("Karen", None) - we will greet Karen, who doesn't find specific age relevant
+
+def greetSomeoneOnTheirBirthday(name: String, age: Option[Int]) = {
+  //perhaps we'll talk about pattern matching in more detail later
+  age match {
+    case Some(age) => s"Happy birthday, dear ${name}. Happy birthday to you. Your ${age}th year is going to be fabulous."
+    case None => s"Happy birthday, dear ${name}. Happy birthday to you."
+  }
+}
+
+greetSomeoneOnTheirBirthday("Karen", Some(45))
+greetSomeoneOnTheirBirthday("Karen", None)
+
+//you might deal with an option like
+val ageMessage = age match {
+  case Some(age) => Some(s"Your ${age}th year is going to be fabulous.")
+  case None => None
+}
+
+val ageMessageIfCheck = {
+  if(age.isDefined) Some(s"Your ${age.get}th year is going to be fabulous.")
+  else None
+}

--- a/2019/src/test/scala/collections/FoldDemoTest.scala
+++ b/2019/src/test/scala/collections/FoldDemoTest.scala
@@ -1,0 +1,8 @@
+package collections
+
+import org.scalatest.FlatSpec
+import OptionsDemo._
+
+class FoldDemoTest extends FlatSpec {
+
+}

--- a/2019/src/test/scala/collections/MapDemoTest.scala
+++ b/2019/src/test/scala/collections/MapDemoTest.scala
@@ -1,0 +1,25 @@
+package collections
+
+import org.scalatest.FlatSpec
+import MapDemo._
+
+class MapDemoTest extends FlatSpec {
+
+  "squarer" should "square every element in a list" in {
+    val numbers = List(1, 2, 3)
+    assert(squarer(numbers) == List(1, 4, 9))
+  }
+
+  it should "do nothing if the list is Nil" in {
+    assert(squarer(Nil) === Nil)
+  }
+
+  "averageGrade" should "return the average grade for a student who is in the table" in {
+    assert(averageGrade("123") == Some(63.75))
+  }
+
+  it should "return None if the student is not known to the table" in {
+    assert(averageGrade("456") == None)
+  }
+
+}

--- a/2019/src/test/scala/collections/OptionsDemoTest.scala
+++ b/2019/src/test/scala/collections/OptionsDemoTest.scala
@@ -1,0 +1,20 @@
+package collections
+
+import org.scalatest.FlatSpec
+import OptionsDemo._
+
+class OptionsDemoTest extends FlatSpec {
+
+  "userHasUpdatedProfile" should "return false if both names are None" in {
+    assert(userHasUpdatedProfile("12345", None, None) == false)
+  }
+
+  it should "return true if both names have values" in {
+    assert(userHasUpdatedProfile("12345", Some("jo"), Some("bloggs")) == true)
+  }
+
+  it should "return true if one of the names has a values" in {
+    assert(userHasUpdatedProfile("12345", Some("jo"), None) == true)
+  }
+
+}


### PR DESCRIPTION
For Scala school 2019, we will have two sessions where we
1. revisit Options
2. discuss mutable/immutable collections and the most common collections
3. map
4. fold (exercises to follow because I want the changes in this PR available in time for the first session)

This PR:
* adds a 2019 folder
* adds Scala worksheets to be used during the more lecture style part of the session
* objects with function definitions (to be implemented) and tests to use as exercises 