### PR TITLE
split out exercise for map the collection

### DIFF
--- a/2019/src/main/scala/collections/CollectionsDemo.scala
+++ b/2019/src/main/scala/collections/CollectionsDemo.scala
@@ -1,0 +1,19 @@
+package collections
+
+object CollectionsDemo {
+
+  val studentResults = Map[String, List[Double]](
+    "123" -> List(57, 50, 70, 78),
+    "124" -> List(60, 60, 51),
+    "125" -> List(55, 57, 78)
+  )
+
+
+
+  //for when you want that student's average grade, if we can find them in the map
+  def averageGrade(studentId: String): Option[Double] = ???
+  //note:
+  //scala> List(1, 2, 3).sum
+  //res38: Int = 6
+
+}

--- a/2019/src/main/scala/collections/MapDemo.scala
+++ b/2019/src/main/scala/collections/MapDemo.scala
@@ -5,17 +5,4 @@ object MapDemo {
   //for when you need to square every element in a list
   def squarer(numbers: List[Int]): List[Int] = ???
 
-  val studentResults = Map[String, List[Double]](
-    "123" -> List(57, 50, 70, 78),
-    "124" -> List(60, 60, 51),
-    "125" -> List(55, 57, 78)
-  )
-
-  //note:
-  //scala> List(1, 2, 3).sum
-  //res38: Int = 6
-
-  def averageGrade(studentId: String): Option[Double] = ???
-
-
 }

--- a/2019/src/main/scala/collections/optionsDemo.sc
+++ b/2019/src/main/scala/collections/optionsDemo.sc
@@ -17,7 +17,7 @@ val noAge: Option[Int] = None
 // greetSomeoneOnTheirBirthday("Karen", Some(45))  -  we will greet Karen, who is 45 today
 // greetSomeoneOnTheirBirthday("Karen", None) - we will greet Karen, who doesn't find specific age relevant
 
-def greetSomeoneOnTheirBirthday(name: String, age: Option[Int]) = {
+def greetSomeoneOnTheirBirthday(name: String, age: Option[Int]): String = {
   //perhaps we'll talk about pattern matching in more detail later
   age match {
     case Some(age) => s"Happy birthday, dear ${name}. Happy birthday to you. Your ${age}th year is going to be fabulous."

--- a/2019/src/main/scala/collections/patternMatch.sc
+++ b/2019/src/main/scala/collections/patternMatch.sc
@@ -1,0 +1,31 @@
+import org.joda.time.DateTime
+//pattern matching = checking a value against a pattern
+
+
+def isThereCurryToday: Boolean = {
+  val today = DateTime.now()
+  val dayOfWeek: Int = today.getDayOfWeek //0 = Sunday
+
+  // we can use it to transform the day of the week to yes/no
+  dayOfWeek match {
+    case 4 => true
+    case _ => false // case _ represents any other integer value
+  }
+}
+
+isThereCurryToday
+
+
+def myAge(age: Option[Int]): String = {
+  //you need an exhaustive match
+  age match {
+    case Some(age) if age == 1=> s"Why, I am $age year of age."
+    case Some(age) => s"Why, I am $age years of age."
+    case None => "That's none of your business!"
+  }
+}
+
+myAge(Some(0))
+myAge(Some(1))
+myAge(Some(-1))
+myAge(None)

--- a/2019/src/test/scala/collections/CollectionsDemoTest.scala
+++ b/2019/src/test/scala/collections/CollectionsDemoTest.scala
@@ -1,0 +1,16 @@
+package collections
+
+import org.scalatest.FlatSpec
+import CollectionsDemo._
+
+class CollectionsDemoTest extends FlatSpec {
+
+  "averageGrade" should "return the average grade for a student who is in the table" in {
+    assert(averageGrade("123") == Some(63.75))
+  }
+
+  it should "return None if the student is not known to the table" in {
+    assert(averageGrade("456") == None)
+  }
+
+}

--- a/2019/src/test/scala/collections/MapDemoTest.scala
+++ b/2019/src/test/scala/collections/MapDemoTest.scala
@@ -14,12 +14,4 @@ class MapDemoTest extends FlatSpec {
     assert(squarer(Nil) === Nil)
   }
 
-  "averageGrade" should "return the average grade for a student who is in the table" in {
-    assert(averageGrade("123") == Some(63.75))
-  }
-
-  it should "return None if the student is not known to the table" in {
-    assert(averageGrade("456") == None)
-  }
-
 }


### PR DESCRIPTION
In https://github.com/guardian/scala-school/pull/6 I added materials for the session on collections for Scala school 2019. 

However, I managed to conflate Map the collection and map the function so I want to split out the exercise for Map the collection to minimise confusion (map the function will be in a separate session).